### PR TITLE
Fix supabase import path

### DIFF
--- a/app/chat/lib/supabase.ts
+++ b/app/chat/lib/supabase.ts
@@ -1,4 +1,4 @@
-import { supabase } from '../../lib/supabase';
+import { supabase } from '../../../lib/supabase';
 import * as naclUtil from 'tweetnacl-util';
 
 export async function uploadPublicKey(userId: string, publicKey: string) {


### PR DESCRIPTION
## Summary
- fix broken path for supabase client

## Testing
- `npx tsc -p tsconfig.json` *(fails: cannot find type definition file for 'jest', expo/tsconfig.base)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c0ba6d6c48322b91fa5d16a0a5582